### PR TITLE
Undo copy only for package lock in SPA templates

### DIFF
--- a/src/content/Angular-CSharp/.template.config/template.json
+++ b/src/content/Angular-CSharp/.template.config/template.json
@@ -25,8 +25,7 @@
         ".template.config/**"
       ],
       "copyOnly": [
-        "wwwroot/**",
-        "ClientApp/package-lock.json"
+        "wwwroot/**"
       ],
       "modifiers": [
         {

--- a/src/content/React-CSharp/.template.config/template.json
+++ b/src/content/React-CSharp/.template.config/template.json
@@ -25,8 +25,7 @@
         ".template.config/**"
       ],
       "copyOnly": [
-        "wwwroot/**",
-        "ClientApp/package-lock.json"
+        "wwwroot/**"
       ],
       "modifiers": [
         {


### PR DESCRIPTION
Now that the template issue has been fixed, we can undo the copy-only