### PR TITLE
Handle errors in setupProxy

### DIFF
--- a/src/content/React-CSharp/ClientApp/src/setupProxy.js
+++ b/src/content/React-CSharp/ClientApp/src/setupProxy.js
@@ -4,7 +4,7 @@ const { env } = require('process');
 const target = env.ASPNETCORE_HTTPS_PORT ? `https://localhost:${env.ASPNETCORE_HTTPS_PORT}` :
   env.ASPNETCORE_URLS ? env.ASPNETCORE_URLS.split(';')[0] : 'http://localhost:8080';
 
-const context =  [
+const context = [
   "/weatherforecast",
 //#if (IndividualLocalAuth)
   "/_configuration",
@@ -15,10 +15,19 @@ const context =  [
 //#endif
 ];
 
-module.exports = function(app) {
+const onError = (err, req, resp, target) => {
+    console.error(`${err.message}`);
+}
+
+module.exports = function (app) {
   const appProxy = createProxyMiddleware(context, {
     target: target,
+    //by handling errors, we prevent the proxy middleware from crashing outright when
+    //the ASP NET Core webserver is unavailable, for example if it has been restarted
+    onError: onError,
     secure: false
+    //uncomment this line if using websockets
+    //ws: true 
   });
 
   app.use(appProxy);


### PR DESCRIPTION
Resolves dotnet/aspnetcore#35155.
Handles errors in setupProxy to prevent the middleware from crashing outright when the backend webserver is unavailable. 

This is particularly prevalent when using websockets, as the middleware polls the websocket every few seconds, which then results in a hard crash if the websocket is unavailable, causing the developer to then need to recompile the front-end part of their application, which can take a significant amount of time.