### PR TITLE
Fix spelling of tableLabel in FetchData.js

### DIFF
--- a/src/content/React-CSharp/ClientApp/src/components/FetchData.js
+++ b/src/content/React-CSharp/ClientApp/src/components/FetchData.js
@@ -17,7 +17,7 @@ export class FetchData extends Component {
 
   static renderForecastsTable(forecasts) {
     return (
-      <table className='table table-striped' aria-labelledby="tabelLabel">
+      <table className='table table-striped' aria-labelledby="tableLabel">
         <thead>
           <tr>
             <th>Date</th>
@@ -47,7 +47,7 @@ export class FetchData extends Component {
 
     return (
       <div>
-        <h1 id="tabelLabel" >Weather forecast</h1>
+        <h1 id="tableLabel" >Weather forecast</h1>
         <p>This component demonstrates fetching data from the server.</p>
         {contents}
       </div>


### PR DESCRIPTION
The default react app generated has a typo in the spelling of tableLabel. This change fixes that.

Addresses https://github.com/dotnet/aspnetcore/issues/37105