### PR TITLE
Add community entry for Vite integration template

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ This section is for community project templates for using ASP.NET Core with vari
 
 > See the [contributing guide](https://github.com/dotnet/spa-templates/blob/main/CONTRIBUTING.md) for details on how to add a project template to this list.
 
+[ASP.NET Core + Vite](https://www.nuget.org/packages/JohannDev.DotNet.Web.Spa.ProjectTemplates/) - ![GitHub stars](https://img.shields.io/github/stars/johanndev/spa-templates?style=flat-square&cacheSeconds=604800&logo=microsoft) ![last commit](https://img.shields.io/github/last-commit/johanndev/spa-templates?style=flat-square&cacheSeconds=86400) Integrates [Vite](https://vitejs.dev/) with ASP.NET Core; currently enables authoring front-end projects in vanilla-js, vue, react, preact, lit-element, and svelte, with optional TypeScript support for all listed technologies.
+
 <!--
 Please use this template for each submission:
 


### PR DESCRIPTION
Adds an entry for the `JohannDev.DotNet.Web.Spa.ProjectTemplates` nuget package, which provides a template for the integration of the Vite frontend tooling with ASP.NET Core.