### PR TITLE
[SPA] Add Keep-Alive header to avoid browser console errors on Mac and Linux

### DIFF
--- a/src/content/Angular-CSharp/ClientApp/proxy.conf.js
+++ b/src/content/Angular-CSharp/ClientApp/proxy.conf.js
@@ -17,7 +17,10 @@ const PROXY_CONFIG = [
 //#endif
    ],
     target: target,
-    secure: false
+    secure: false,
+    headers: {
+      Connection: 'Keep-Alive'
+    }
   }
 ]
 

--- a/src/content/React-CSharp/ClientApp/src/setupProxy.js
+++ b/src/content/React-CSharp/ClientApp/src/setupProxy.js
@@ -19,7 +19,10 @@ const context =  [
 module.exports = function(app) {
   const appProxy = createProxyMiddleware(context, {
     target: target,
-    secure: false
+    secure: false,
+    headers: {
+      Connection: 'Keep-Alive'
+    }
   });
 
   app.use(appProxy);


### PR DESCRIPTION
## Description
We are making sure the proxy sends the Keep-Alive header to avoid connection close/reset issues in the proxy on Mac and Linux.

## Customer Impact

Customers see a lot of errors on the browser console that increase the noise during development on Mac and Linux.

## Regression?

- [X] Yes
- [ ] No

There were no browser errors on the console for previous versions of the application.

## Risk

- [ ] High
- [ ] Medium
- [X] Low

The code is on the template and customers can easily revert the change if there's anything wrong on it.

## Verification

- [x] Manual (required)
- [ ] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [X] N/A

Fixes https://github.com/dotnet/aspnetcore/issues/37681