### PR TITLE
Reduce unnecessary requests

### DIFF
--- a/src/content/React-CSharp/ClientApp/src/components/api-authorization/AuthorizeService.js
+++ b/src/content/React-CSharp/ClientApp/src/components/api-authorization/AuthorizeService.js
@@ -174,7 +174,7 @@ export class AuthorizeService {
         return { status: AuthenticationResultStatus.Redirect };
     }
 
-    async ensureUserManagerInitialized() {
+    async _ensureUserManagerInitialized() {
         if (this.userManager !== undefined) {
             return;
         }
@@ -198,6 +198,15 @@ export class AuthorizeService {
             this.updateState(undefined);
         });
     }
+    
+    ensureUserManagerInitialized = (() => {
+        let chain = Promise.resolve();
+        return () => {
+            const next = chain.then(this._ensureUserManagerInitialized.bind(this));
+            chain = next.catch(() => {});
+            return next;
+        }
+    })();
 
     static get instance() { return authService }
 }


### PR DESCRIPTION
`fetch(ApplicationPaths.ApiAuthorizationClientConfigurationUrl)` will be executed multiple times when the page is opened. This patch fixes the problem.