### PR TITLE
Handle paths with whitespace.

### DIFF
--- a/src/content/Angular-CSharp/ClientApp/package.json
+++ b/src/content/Angular-CSharp/ClientApp/package.json
@@ -6,8 +6,8 @@
 //#if(RequiresHttps)
     "prestart": "node aspnetcore-https",
     "start": "run-script-os",
-    "start:windows": "ng serve --port 5002 --ssl --ssl-cert %APPDATA%\\ASP.NET\\https\\%npm_package_name%.pem --ssl-key %APPDATA%\\ASP.NET\\https\\%npm_package_name%.key",
-    "start:default": "ng serve --port 5002 --ssl --ssl-cert $HOME/.aspnet/https/${npm_package_name}.pem --ssl-key $HOME/.aspnet/https/${npm_package_name}.key",
+    "start:windows": "ng serve --port 5002 --ssl --ssl-cert \"%APPDATA%\\ASP.NET\\https\\%npm_package_name%.pem\" --ssl-key \"%APPDATA%\\ASP.NET\\https\\%npm_package_name%.key\"",
+    "start:default": "ng serve --port 5002 --ssl --ssl-cert \"$HOME/.aspnet/https/${npm_package_name}.pem\" --ssl-key \"$HOME/.aspnet/https/${npm_package_name}.key\"",
 //#else
     "start": "ng serve --port 5002",
 //#endif


### PR DESCRIPTION
The missing quotation marks are usually a problem for local Windows accounts when the user entered its name e.g. "John Doe" during account creation.

I don't know if this problem may exist on non-Windows operating systems, but IMHO it's better to be safe than sorrow.