### PR TITLE
Update package.json start script

### DIFF
--- a/src/content/Angular-CSharp/ClientApp/package.json
+++ b/src/content/Angular-CSharp/ClientApp/package.json
@@ -6,7 +6,7 @@
 //#if(RequiresHttps)
     "prestart": "node aspnetcore-https",
     "start": "run-script-os",
-    "start:windows": "ng serve --port 5002 --ssl --ssl-cert %APPDATA%\\ASP.NET\\https\\%npm_package_name%.pem --ssl-key %APPDATA%\\ASP.NET\\https\\%npm_package_name%.key",
+    "start:windows": "ng serve --port 5002 --ssl --ssl-cert \"%APPDATA%\"\\ASP.NET\\https\\%npm_package_name%.pem --ssl-key \"%APPDATA%\"\\ASP.NET\\https\\%npm_package_name%.key",
     "start:default": "ng serve --port 5002 --ssl --ssl-cert $HOME/.aspnet/https/${npm_package_name}.pem --ssl-key $HOME/.aspnet/https/${npm_package_name}.key",
 //#else
     "start": "ng serve --port 5002",


### PR DESCRIPTION
If the windows username contains a space e.g. 'Anuj Agrawal', the start script fails. This was frustrating as the VS debug option doesn't show this error, not on console, not even on Output window. Adding double quotes around the variable APPDATA solves this.