### PR TITLE
Rewrite React template as function component with hooks

### DIFF
--- a/src/content/React-CSharp/ClientApp/src/App.js
+++ b/src/content/React-CSharp/ClientApp/src/App.js
@@ -1,33 +1,29 @@
-import React, { Component } from 'react';
+import React from 'react';
 import { Route } from 'react-router';
 import { Layout } from './components/Layout';
 import { Home } from './components/Home';
 import { FetchData } from './components/FetchData';
 import { Counter } from './components/Counter';
 ////#if (IndividualLocalAuth)
-import AuthorizeRoute from './components/api-authorization/AuthorizeRoute';
-import ApiAuthorizationRoutes from './components/api-authorization/ApiAuthorizationRoutes';
+import { AuthorizeRoute } from './components/api-authorization/AuthorizeRoute';
+import { ApiAuthorizationRoutes } from './components/api-authorization/ApiAuthorizationRoutes';
 import { ApplicationPaths } from './components/api-authorization/ApiAuthorizationConstants';
 ////#endif
 
 import './custom.css'
 
-export default class App extends Component {
-  static displayName = App.name;
-
-  render () {
-    return (
-      <Layout>
-        <Route exact path='/' component={Home} />
-        <Route path='/counter' component={Counter} />
-////#if (!IndividualLocalAuth)
-        <Route path='/fetch-data' component={FetchData} />
-////#endif
-////#if (IndividualLocalAuth)
-        <AuthorizeRoute path='/fetch-data' component={FetchData} />
-        <Route path={ApplicationPaths.ApiAuthorizationPrefix} component={ApiAuthorizationRoutes} />
-////#endif
-      </Layout>
-    );
-  }
+export function App() {
+  return (
+    <Layout>
+      <Route exact path='/' component={Home} />
+      <Route path='/counter' component={Counter} />
+      ////#if (!IndividualLocalAuth)
+      <Route path='/fetch-data' component={FetchData} />
+      ////#endif
+      ////#if (IndividualLocalAuth)
+      <AuthorizeRoute path='/fetch-data' component={FetchData} />
+      <Route path={ApplicationPaths.ApiAuthorizationPrefix} component={ApiAuthorizationRoutes} />
+      ////#endif
+    </Layout>
+  );
 }

--- a/src/content/React-CSharp/ClientApp/src/components/Counter.js
+++ b/src/content/React-CSharp/ClientApp/src/components/Counter.js
@@ -4,7 +4,7 @@ import { useState } from 'react';
 export function Counter() {
   const [currentCount, setCurrentCount] = useState(0);
 
-  const incrementCounter = () => setCurrentCount(currentCount + 1);
+  const incrementCounter = () => setCurrentCount(count => count + 1);
   
   return (
     <div>

--- a/src/content/React-CSharp/ClientApp/src/components/Counter.js
+++ b/src/content/React-CSharp/ClientApp/src/components/Counter.js
@@ -1,31 +1,20 @@
-import React, { Component } from 'react';
+import React from 'react';
+import { useState } from 'react';
 
-export class Counter extends Component {
-  static displayName = Counter.name;
+export function Counter() {
+  const [currentCount, setCurrentCount] = useState(0);
 
-  constructor(props) {
-    super(props);
-    this.state = { currentCount: 0 };
-    this.incrementCounter = this.incrementCounter.bind(this);
-  }
+  const incrementCounter = () => setCurrentCount(currentCount + 1);
+  
+  return (
+    <div>
+      <h1>Counter</h1>
 
-  incrementCounter() {
-    this.setState({
-      currentCount: this.state.currentCount + 1
-    });
-  }
+      <p>This is a simple example of a React component.</p>
 
-  render() {
-    return (
-      <div>
-        <h1>Counter</h1>
+      <p aria-live="polite">Current count: <strong>{currentCount}</strong></p>
 
-        <p>This is a simple example of a React component.</p>
-
-        <p aria-live="polite">Current count: <strong>{this.state.currentCount}</strong></p>
-
-        <button className="btn btn-primary" onClick={this.incrementCounter}>Increment</button>
-      </div>
-    );
-  }
+      <button className="btn btn-primary" onClick={incrementCounter}>Increment</button>
+    </div>
+  );
 }

--- a/src/content/React-CSharp/ClientApp/src/components/FetchData.js
+++ b/src/content/React-CSharp/ClientApp/src/components/FetchData.js
@@ -8,7 +8,7 @@ export function FetchData() {
   const [forecasts, setForecasts] = useState([]);
   const [loading, setLoading] = useState(true);
   
-  useEffect(async () => {
+  useEffect(() => {
     populateWeatherData();
   }, [])
   

--- a/src/content/React-CSharp/ClientApp/src/components/FetchData.js
+++ b/src/content/React-CSharp/ClientApp/src/components/FetchData.js
@@ -1,71 +1,65 @@
-import React, { Component } from 'react';
+import React from 'react';
+import { useState, useEffect } from 'react';
 ////#if (IndividualLocalAuth)
 import authService from './api-authorization/AuthorizeService'
 ////#endif
 
-export class FetchData extends Component {
-  static displayName = FetchData.name;
+export function FetchData() {
+  const [forecasts, setForecasts] = useState([]);
+  const [loading, setLoading] = useState(true);
+  
+  useEffect(async () => {
+    populateWeatherData();
+  }, [])
+  
+  const populateWeatherData = async () => {
+    ////#if (IndividualLocalAuth)
+    const token = await authService.getAccessToken();
+    const response = await fetch('weatherforecast', {
+      headers: !token ? {} : {'Authorization': `Bearer ${token}`}
+    });
+    ////#else
+    const response = await fetch('weatherforecast');
+    ////#endif
+    const data = await response.json();
+    setForecasts(data);
+    setLoading(false);
+  };
 
-  constructor(props) {
-    super(props);
-    this.state = { forecasts: [], loading: true };
-  }
-
-  componentDidMount() {
-    this.populateWeatherData();
-  }
-
-  static renderForecastsTable(forecasts) {
+  const renderForecastsTable = (forecasts) => {
     return (
       <table className='table table-striped' aria-labelledby="tableLabel">
         <thead>
-          <tr>
-            <th>Date</th>
-            <th>Temp. (C)</th>
-            <th>Temp. (F)</th>
-            <th>Summary</th>
-          </tr>
+        <tr>
+          <th>Date</th>
+          <th>Temp. (C)</th>
+          <th>Temp. (F)</th>
+          <th>Summary</th>
+        </tr>
         </thead>
         <tbody>
-          {forecasts.map(forecast =>
-            <tr key={forecast.date}>
-              <td>{forecast.date}</td>
-              <td>{forecast.temperatureC}</td>
-              <td>{forecast.temperatureF}</td>
-              <td>{forecast.summary}</td>
-            </tr>
-          )}
+        {forecasts.map(forecast =>
+          <tr key={forecast.date}>
+            <td>{forecast.date}</td>
+            <td>{forecast.temperatureC}</td>
+            <td>{forecast.temperatureF}</td>
+            <td>{forecast.summary}</td>
+          </tr>
+        )}
         </tbody>
       </table>
     );
   }
 
-  render() {
-    let contents = this.state.loading
+  let contents = loading
       ? <p><em>Loading...</em></p>
-      : FetchData.renderForecastsTable(this.state.forecasts);
+      : renderForecastsTable(forecasts);
 
-    return (
-      <div>
-        <h1 id="tableLabel">Weather forecast</h1>
-        <p>This component demonstrates fetching data from the server.</p>
-        {contents}
-      </div>
-    );
-  }
-
-  async populateWeatherData() {
-    ////#if (IndividualLocalAuth)
-    const token = await authService.getAccessToken();
-    const response = await fetch('weatherforecast', {
-      headers: !token ? {} : { 'Authorization': `Bearer ${token}` }
-    });
-    const data = await response.json();
-    this.setState({ forecasts: data, loading: false });
-    ////#else
-    const response = await fetch('weatherforecast');
-    const data = await response.json();
-    this.setState({ forecasts: data, loading: false });
-    ////#endif
-  }
+  return (
+    <div>
+      <h1 id="tableLabel">Weather forecast</h1>
+      <p>This component demonstrates fetching data from the server.</p>
+      {contents}
+    </div>
+  );
 }

--- a/src/content/React-CSharp/ClientApp/src/components/Home.js
+++ b/src/content/React-CSharp/ClientApp/src/components/Home.js
@@ -1,26 +1,22 @@
-import React, { Component } from 'react';
+import React from 'react';
 
-export class Home extends Component {
-  static displayName = Home.name;
-
-  render () {
-    return (
-      <div>
-        <h1>Hello, world!</h1>
-        <p>Welcome to your new single-page application, built with:</p>
-        <ul>
-          <li><a href='https://get.asp.net/'>ASP.NET Core</a> and <a href='https://msdn.microsoft.com/en-us/library/67ef8sbd.aspx'>C#</a> for cross-platform server-side code</li>
-          <li><a href='https://facebook.github.io/react/'>React</a> for client-side code</li>
-          <li><a href='http://getbootstrap.com/'>Bootstrap</a> for layout and styling</li>
-        </ul>
-        <p>To help you get started, we have also set up:</p>
-        <ul>
-          <li><strong>Client-side navigation</strong>. For example, click <em>Counter</em> then <em>Back</em> to return here.</li>
-          <li><strong>Development server integration</strong>. In development mode, the development server from <code>create-react-app</code> runs in the background automatically, so your client-side resources are dynamically built on demand and the page refreshes when you modify any file.</li>
-          <li><strong>Efficient production builds</strong>. In production mode, development-time features are disabled, and your <code>dotnet publish</code> configuration produces minified, efficiently bundled JavaScript files.</li>
-        </ul>
-        <p>The <code>ClientApp</code> subdirectory is a standard React application based on the <code>create-react-app</code> template. If you open a command prompt in that directory, you can run <code>npm</code> commands such as <code>npm test</code> or <code>npm install</code>.</p>
-      </div>
-    );
-  }
+export function Home() {
+  return (
+    <div>
+      <h1>Hello, world!</h1>
+      <p>Welcome to your new single-page application, built with:</p>
+      <ul>
+        <li><a href='https://get.asp.net/'>ASP.NET Core</a> and <a href='https://msdn.microsoft.com/en-us/library/67ef8sbd.aspx'>C#</a> for cross-platform server-side code</li>
+        <li><a href='https://facebook.github.io/react/'>React</a> for client-side code</li>
+        <li><a href='http://getbootstrap.com/'>Bootstrap</a> for layout and styling</li>
+      </ul>
+      <p>To help you get started, we have also set up:</p>
+      <ul>
+        <li><strong>Client-side navigation</strong>. For example, click <em>Counter</em> then <em>Back</em> to return here.</li>
+        <li><strong>Development server integration</strong>. In development mode, the development server from <code>create-react-app</code> runs in the background automatically, so your client-side resources are dynamically built on demand and the page refreshes when you modify any file.</li>
+        <li><strong>Efficient production builds</strong>. In production mode, development-time features are disabled, and your <code>dotnet publish</code> configuration produces minified, efficiently bundled JavaScript files.</li>
+      </ul>
+      <p>The <code>ClientApp</code> subdirectory is a standard React application based on the <code>create-react-app</code> template. If you open a command prompt in that directory, you can run <code>npm</code> commands such as <code>npm test</code> or <code>npm install</code>.</p>
+    </div>
+  );
 }

--- a/src/content/React-CSharp/ClientApp/src/components/Layout.js
+++ b/src/content/React-CSharp/ClientApp/src/components/Layout.js
@@ -1,18 +1,14 @@
-import React, { Component } from 'react';
+import React from 'react';
 import { Container } from 'reactstrap';
 import { NavMenu } from './NavMenu';
 
-export class Layout extends Component {
-  static displayName = Layout.name;
-
-  render () {
-    return (
-      <div>
-        <NavMenu />
-        <Container>
-          {this.props.children}
-        </Container>
-      </div>
-    );
-  }
+export function Layout({children}) {
+  return (
+    <div>
+      <NavMenu />
+      <Container>
+        {children})
+      </Container>
+    </div>
+  );
 }

--- a/src/content/React-CSharp/ClientApp/src/components/NavMenu.js
+++ b/src/content/React-CSharp/ClientApp/src/components/NavMenu.js
@@ -10,7 +10,7 @@ import './NavMenu.css';
 export function NavMenu() {
   const [collapsed, setCollapsed] = useState(true);
 
-  const toggleNavbar = () => setCollapsed(!collapsed);
+  const toggleNavbar = () => setCollapsed(current => !current);
 
   return (
     <header>

--- a/src/content/React-CSharp/ClientApp/src/components/NavMenu.js
+++ b/src/content/React-CSharp/ClientApp/src/components/NavMenu.js
@@ -1,4 +1,5 @@
-import React, { Component } from 'react';
+import React from 'react';
+import { useState } from 'react';
 import { Collapse, Container, Navbar, NavbarBrand, NavbarToggler, NavItem, NavLink } from 'reactstrap';
 import { Link } from 'react-router-dom';
 ////#if (IndividualLocalAuth)
@@ -6,51 +7,36 @@ import { LoginMenu } from './api-authorization/LoginMenu';
 ////#endif
 import './NavMenu.css';
 
-export class NavMenu extends Component {
-  static displayName = NavMenu.name;
+export function NavMenu() {
+  const [collapsed, setCollapsed] = useState(true);
 
-  constructor (props) {
-    super(props);
+  const toggleNavbar = () => setCollapsed(!collapsed);
 
-    this.toggleNavbar = this.toggleNavbar.bind(this);
-    this.state = {
-      collapsed: true
-    };
-  }
-
-  toggleNavbar () {
-    this.setState({
-      collapsed: !this.state.collapsed
-    });
-  }
-
-  render () {
-    return (
-      <header>
-        <Navbar className="navbar-expand-sm navbar-toggleable-sm ng-white border-bottom box-shadow mb-3" light>
-          <Container>
-            <NavbarBrand tag={Link} to="/">Company.WebApplication1</NavbarBrand>
-            <NavbarToggler onClick={this.toggleNavbar} className="mr-2" />
-            <Collapse className="d-sm-inline-flex flex-sm-row-reverse" isOpen={!this.state.collapsed} navbar>
-              <ul className="navbar-nav flex-grow">
-                <NavItem>
-                  <NavLink tag={Link} className="text-dark" to="/">Home</NavLink>
-                </NavItem>
-                <NavItem>
-                  <NavLink tag={Link} className="text-dark" to="/counter">Counter</NavLink>
-                </NavItem>
-                <NavItem>
-                  <NavLink tag={Link} className="text-dark" to="/fetch-data">Fetch data</NavLink>
-                </NavItem>
-////#if (IndividualLocalAuth)
-                <LoginMenu>
-                </LoginMenu>
-////#endif
-              </ul>
-            </Collapse>
-          </Container>
-        </Navbar>
-      </header>
-    );
-  }
+  return (
+    <header>
+      <Navbar className="navbar-expand-sm navbar-toggleable-sm ng-white border-bottom box-shadow mb-3" light>
+        <Container>
+          <NavbarBrand tag={Link} to="/">Company.WebApplication1</NavbarBrand>
+          <NavbarToggler onClick={toggleNavbar} className="mr-2" />
+          <Collapse className="d-sm-inline-flex flex-sm-row-reverse" isOpen={!collapsed} navbar>
+            <ul className="navbar-nav flex-grow">
+              <NavItem>
+                <NavLink tag={Link} className="text-dark" to="/">Home</NavLink>
+              </NavItem>
+              <NavItem>
+                <NavLink tag={Link} className="text-dark" to="/counter">Counter</NavLink>
+              </NavItem>
+              <NavItem>
+                <NavLink tag={Link} className="text-dark" to="/fetch-data">Fetch data</NavLink>
+              </NavItem>
+              ////#if (IndividualLocalAuth)
+              <LoginMenu>
+              </LoginMenu>
+              ////#endif
+            </ul>
+          </Collapse>
+        </Container>
+      </Navbar>
+    </header>
+  );
 }

--- a/src/content/React-CSharp/ClientApp/src/components/api-authorization/ApiAuthorizationRoutes.js
+++ b/src/content/React-CSharp/ClientApp/src/components/api-authorization/ApiAuthorizationRoutes.js
@@ -1,30 +1,23 @@
-import React, { Component, Fragment } from 'react';
+import React from 'react';
+import { Fragment } from 'react';
 import { Route } from 'react-router';
-import { Login } from './Login'
-import { Logout } from './Logout'
+import { Login } from './Login';
+import { Logout } from './Logout';
 import { ApplicationPaths, LoginActions, LogoutActions } from './ApiAuthorizationConstants';
 
-export default class ApiAuthorizationRoutes extends Component {
-
-  render () {
-    return(
-      <Fragment>
-          <Route path={ApplicationPaths.Login} render={() => loginAction(LoginActions.Login)} />
-          <Route path={ApplicationPaths.LoginFailed} render={() => loginAction(LoginActions.LoginFailed)} />
-          <Route path={ApplicationPaths.LoginCallback} render={() => loginAction(LoginActions.LoginCallback)} />
-          <Route path={ApplicationPaths.Profile} render={() => loginAction(LoginActions.Profile)} />
-          <Route path={ApplicationPaths.Register} render={() => loginAction(LoginActions.Register)} />
-          <Route path={ApplicationPaths.LogOut} render={() => logoutAction(LogoutActions.Logout)} />
-          <Route path={ApplicationPaths.LogOutCallback} render={() => logoutAction(LogoutActions.LogoutCallback)} />
-          <Route path={ApplicationPaths.LoggedOut} render={() => logoutAction(LogoutActions.LoggedOut)} />
-      </Fragment>);
-  }
-}
-
-function loginAction(name){
-    return (<Login action={name}></Login>);
-}
-
-function logoutAction(name) {
-    return (<Logout action={name}></Logout>);
+export function ApiAuthorizationRoutes() {
+  const loginAction = (name) => (<Login action={name}/>);
+  const logoutAction = (name) => (<Logout action={name}/>);
+  
+  return(
+    <Fragment>
+      <Route path={ApplicationPaths.Login} render={() => loginAction(LoginActions.Login)} />
+      <Route path={ApplicationPaths.LoginFailed} render={() => loginAction(LoginActions.LoginFailed)} />
+      <Route path={ApplicationPaths.LoginCallback} render={() => loginAction(LoginActions.LoginCallback)} />
+      <Route path={ApplicationPaths.Profile} render={() => loginAction(LoginActions.Profile)} />
+      <Route path={ApplicationPaths.Register} render={() => loginAction(LoginActions.Register)} />
+      <Route path={ApplicationPaths.LogOut} render={() => logoutAction(LogoutActions.Logout)} />
+      <Route path={ApplicationPaths.LogOutCallback} render={() => logoutAction(LogoutActions.LogoutCallback)} />
+      <Route path={ApplicationPaths.LoggedOut} render={() => logoutAction(LogoutActions.LoggedOut)} />
+    </Fragment>);
 }

--- a/src/content/React-CSharp/ClientApp/src/components/api-authorization/AuthorizeRoute.js
+++ b/src/content/React-CSharp/ClientApp/src/components/api-authorization/AuthorizeRoute.js
@@ -5,19 +5,16 @@ import { ApplicationPaths, QueryParameterNames } from './ApiAuthorizationConstan
 import authService from './AuthorizeService';
 
 export function AuthorizeRoute(props) {
-  const [ready, setReady] = useState(false);
-  const [authenticated, setAuthenticated] = useState(false);
+  const [state, setState] = useState({ready: false, authenticated: false});
 
   useEffect(() => {
     const populateAuthenticationState = async () => {
       const authenticated = await authService.isAuthenticated();
-      setReady(true);
-      setAuthenticated(authenticated);
+      setState({ready: true, authenticated: authenticated});
     };
 
     const authenticationChanged = async () => {
-      setReady(false);
-      setAuthenticated(false);
+      setState({ready: false, authenticated: false});
       await populateAuthenticationState();
     };
 
@@ -30,13 +27,13 @@ export function AuthorizeRoute(props) {
   link.href = props.path;
   const returnUrl = `${link.protocol}//${link.host}${link.pathname}${link.search}${link.hash}`;
   const redirectUrl = `${ApplicationPaths.Login}?${QueryParameterNames.ReturnUrl}=${encodeURIComponent(returnUrl)}`
-  if (!ready) {
+  if (!state.ready) {
     return <div></div>;
   } else {
     const { component: Component, ...rest } = props;
     return <Route {...rest}
                   render={(props) => {
-                    if (authenticated) {
+                    if (state.authenticated) {
                       return <Component {...props} />
                     } else {
                       return <Redirect to={redirectUrl} />

--- a/src/content/React-CSharp/ClientApp/src/components/api-authorization/AuthorizeRoute.js
+++ b/src/content/React-CSharp/ClientApp/src/components/api-authorization/AuthorizeRoute.js
@@ -1,56 +1,46 @@
-import React from 'react'
-import { Component } from 'react'
-import { Route, Redirect } from 'react-router-dom'
-import { ApplicationPaths, QueryParameterNames } from './ApiAuthorizationConstants'
-import authService from './AuthorizeService'
+import React from 'react';
+import { useState, useEffect } from 'react';
+import { Route, Redirect } from 'react-router-dom';
+import { ApplicationPaths, QueryParameterNames } from './ApiAuthorizationConstants';
+import authService from './AuthorizeService';
 
-export default class AuthorizeRoute extends Component {
-    constructor(props) {
-        super(props);
+export function AuthorizeRoute(props) {
+  const [ready, setReady] = useState(false);
+  const [authenticated, setAuthenticated] = useState(false);
 
-        this.state = {
-            ready: false,
-            authenticated: false
-        };
-    }
+  useEffect(() => {
+    const populateAuthenticationState = async () => {
+      const authenticated = await authService.isAuthenticated();
+      setReady(true);
+      setAuthenticated(authenticated);
+    };
 
-    componentDidMount() {
-        this._subscription = authService.subscribe(() => this.authenticationChanged());
-        this.populateAuthenticationState();
-    }
+    const authenticationChanged = async () => {
+      setReady(false);
+      setAuthenticated(false);
+      await populateAuthenticationState();
+    };
 
-    componentWillUnmount() {
-        authService.unsubscribe(this._subscription);
-    }
+    const subscription = authService.subscribe(() => authenticationChanged());
+    populateAuthenticationState();
+    return () => authService.unsubscribe(subscription);
+  }, [])
 
-    render() {
-        const { ready, authenticated } = this.state;
-        var link = document.createElement("a");
-        link.href = this.props.path;
-        const returnUrl = `${link.protocol}//${link.host}${link.pathname}${link.search}${link.hash}`;
-        const redirectUrl = `${ApplicationPaths.Login}?${QueryParameterNames.ReturnUrl}=${encodeURIComponent(returnUrl)}`
-        if (!ready) {
-            return <div></div>;
-        } else {
-            const { component: Component, ...rest } = this.props;
-            return <Route {...rest}
-                render={(props) => {
+  const link = document.createElement("a");
+  link.href = props.path;
+  const returnUrl = `${link.protocol}//${link.host}${link.pathname}${link.search}${link.hash}`;
+  const redirectUrl = `${ApplicationPaths.Login}?${QueryParameterNames.ReturnUrl}=${encodeURIComponent(returnUrl)}`
+  if (!ready) {
+    return <div></div>;
+  } else {
+    const { component: Component, ...rest } = props;
+    return <Route {...rest}
+                  render={(props) => {
                     if (authenticated) {
-                        return <Component {...props} />
+                      return <Component {...props} />
                     } else {
-                        return <Redirect to={redirectUrl} />
+                      return <Redirect to={redirectUrl} />
                     }
-                }} />
-        }
-    }
-
-    async populateAuthenticationState() {
-        const authenticated = await authService.isAuthenticated();
-        this.setState({ ready: true, authenticated });
-    }
-
-    async authenticationChanged() {
-        this.setState({ ready: false, authenticated: false });
-        await this.populateAuthenticationState();
-    }
+                  }} />
+  }
 }

--- a/src/content/React-CSharp/ClientApp/src/components/api-authorization/AuthorizeService.js
+++ b/src/content/React-CSharp/ClientApp/src/components/api-authorization/AuthorizeService.js
@@ -2,204 +2,204 @@ import { UserManager, WebStorageStateStore } from 'oidc-client';
 import { ApplicationPaths, ApplicationName } from './ApiAuthorizationConstants';
 
 export class AuthorizeService {
-    _callbacks = [];
-    _nextSubscriptionId = 0;
-    _user = null;
-    _isAuthenticated = false;
+  _callbacks = [];
+  _nextSubscriptionId = 0;
+  _user = null;
+  _isAuthenticated = false;
 
-    // By default pop ups are disabled because they don't work properly on Edge.
-    // If you want to enable pop up authentication simply set this flag to false.
-    _popUpDisabled = true;
+  // By default pop ups are disabled because they don't work properly on Edge.
+  // If you want to enable pop up authentication simply set this flag to false.
+  _popUpDisabled = true;
 
-    async isAuthenticated() {
-        const user = await this.getUser();
-        return !!user;
+  async isAuthenticated() {
+    const user = await this.getUser();
+    return !!user;
+  }
+
+  async getUser() {
+    if (this._user && this._user.profile) {
+      return this._user.profile;
     }
 
-    async getUser() {
-        if (this._user && this._user.profile) {
-            return this._user.profile;
+    await this.ensureUserManagerInitialized();
+    const user = await this.userManager.getUser();
+    return user && user.profile;
+  }
+
+  async getAccessToken() {
+    await this.ensureUserManagerInitialized();
+    const user = await this.userManager.getUser();
+    return user && user.access_token;
+  }
+
+  // We try to authenticate the user in three different ways:
+  // 1) We try to see if we can authenticate the user silently. This happens
+  //    when the user is already logged in on the IdP and is done using a hidden iframe
+  //    on the client.
+  // 2) We try to authenticate the user using a PopUp Window. This might fail if there is a
+  //    Pop-Up blocker or the user has disabled PopUps.
+  // 3) If the two methods above fail, we redirect the browser to the IdP to perform a traditional
+  //    redirect flow.
+  async signIn(state) {
+    await this.ensureUserManagerInitialized();
+    try {
+      const silentUser = await this.userManager.signinSilent(this.createArguments());
+      this.updateState(silentUser);
+      return this.success(state);
+    } catch (silentError) {
+      // User might not be authenticated, fallback to popup authentication
+      console.log("Silent authentication error: ", silentError);
+
+      try {
+        if (this._popUpDisabled) {
+          throw new Error('Popup disabled. Change \'AuthorizeService.js:AuthorizeService._popupDisabled\' to false to enable it.')
         }
 
-        await this.ensureUserManagerInitialized();
-        const user = await this.userManager.getUser();
-        return user && user.profile;
-    }
+        const popUpUser = await this.userManager.signinPopup(this.createArguments());
+        this.updateState(popUpUser);
+        return this.success(state);
+      } catch (popUpError) {
+        if (popUpError.message === "Popup window closed") {
+          // The user explicitly cancelled the login action by closing an opened popup.
+          return this.error("The user closed the window.");
+        } else if (!this._popUpDisabled) {
+          console.log("Popup authentication error: ", popUpError);
+        }
 
-    async getAccessToken() {
-        await this.ensureUserManagerInitialized();
-        const user = await this.userManager.getUser();
-        return user && user.access_token;
-    }
-
-    // We try to authenticate the user in three different ways:
-    // 1) We try to see if we can authenticate the user silently. This happens
-    //    when the user is already logged in on the IdP and is done using a hidden iframe
-    //    on the client.
-    // 2) We try to authenticate the user using a PopUp Window. This might fail if there is a
-    //    Pop-Up blocker or the user has disabled PopUps.
-    // 3) If the two methods above fail, we redirect the browser to the IdP to perform a traditional
-    //    redirect flow.
-    async signIn(state) {
-        await this.ensureUserManagerInitialized();
+        // PopUps might be blocked by the user, fallback to redirect
         try {
-            const silentUser = await this.userManager.signinSilent(this.createArguments());
-            this.updateState(silentUser);
-            return this.success(state);
-        } catch (silentError) {
-            // User might not be authenticated, fallback to popup authentication
-            console.log("Silent authentication error: ", silentError);
-
-            try {
-                if (this._popUpDisabled) {
-                    throw new Error('Popup disabled. Change \'AuthorizeService.js:AuthorizeService._popupDisabled\' to false to enable it.')
-                }
-
-                const popUpUser = await this.userManager.signinPopup(this.createArguments());
-                this.updateState(popUpUser);
-                return this.success(state);
-            } catch (popUpError) {
-                if (popUpError.message === "Popup window closed") {
-                    // The user explicitly cancelled the login action by closing an opened popup.
-                    return this.error("The user closed the window.");
-                } else if (!this._popUpDisabled) {
-                    console.log("Popup authentication error: ", popUpError);
-                }
-
-                // PopUps might be blocked by the user, fallback to redirect
-                try {
-                    await this.userManager.signinRedirect(this.createArguments(state));
-                    return this.redirect();
-                } catch (redirectError) {
-                    console.log("Redirect authentication error: ", redirectError);
-                    return this.error(redirectError);
-                }
-            }
+          await this.userManager.signinRedirect(this.createArguments(state));
+          return this.redirect();
+        } catch (redirectError) {
+          console.log("Redirect authentication error: ", redirectError);
+          return this.error(redirectError);
         }
+      }
+    }
+  }
+
+  async completeSignIn(url) {
+    try {
+      await this.ensureUserManagerInitialized();
+      const user = await this.userManager.signinCallback(url);
+      this.updateState(user);
+      return this.success(user && user.state);
+    } catch (error) {
+      console.log('There was an error signing in: ', error);
+      return this.error('There was an error signing in.');
+    }
+  }
+
+  // We try to sign out the user in two different ways:
+  // 1) We try to do a sign-out using a PopUp Window. This might fail if there is a
+  //    Pop-Up blocker or the user has disabled PopUps.
+  // 2) If the method above fails, we redirect the browser to the IdP to perform a traditional
+  //    post logout redirect flow.
+  async signOut(state) {
+    await this.ensureUserManagerInitialized();
+    try {
+      if (this._popUpDisabled) {
+        throw new Error('Popup disabled. Change \'AuthorizeService.js:AuthorizeService._popupDisabled\' to false to enable it.')
+      }
+
+      await this.userManager.signoutPopup(this.createArguments());
+      this.updateState(undefined);
+      return this.success(state);
+    } catch (popupSignOutError) {
+      console.log("Popup signout error: ", popupSignOutError);
+      try {
+        await this.userManager.signoutRedirect(this.createArguments(state));
+        return this.redirect();
+      } catch (redirectSignOutError) {
+        console.log("Redirect signout error: ", redirectSignOutError);
+        return this.error(redirectSignOutError);
+      }
+    }
+  }
+
+  async completeSignOut(url) {
+    await this.ensureUserManagerInitialized();
+    try {
+      const response = await this.userManager.signoutCallback(url);
+      this.updateState(null);
+      return this.success(response && response.data);
+    } catch (error) {
+      console.log(`There was an error trying to log out '${error}'.`);
+      return this.error(error);
+    }
+  }
+
+  updateState(user) {
+    this._user = user;
+    this._isAuthenticated = !!this._user;
+    this.notifySubscribers();
+  }
+
+  subscribe(callback) {
+    this._callbacks.push({ callback, subscription: this._nextSubscriptionId++ });
+    return this._nextSubscriptionId - 1;
+  }
+
+  unsubscribe(subscriptionId) {
+    const subscriptionIndex = this._callbacks
+      .map((element, index) => element.subscription === subscriptionId ? { found: true, index } : { found: false })
+      .filter(element => element.found === true);
+    if (subscriptionIndex.length !== 1) {
+      throw new Error(`Found an invalid number of subscriptions ${subscriptionIndex.length}`);
     }
 
-    async completeSignIn(url) {
-        try {
-            await this.ensureUserManagerInitialized();
-            const user = await this.userManager.signinCallback(url);
-            this.updateState(user);
-            return this.success(user && user.state);
-        } catch (error) {
-            console.log('There was an error signing in: ', error);
-            return this.error('There was an error signing in.');
-        }
+    this._callbacks.splice(subscriptionIndex[0].index, 1);
+  }
+
+  notifySubscribers() {
+    for (let i = 0; i < this._callbacks.length; i++) {
+      const callback = this._callbacks[i].callback;
+      callback();
+    }
+  }
+
+  createArguments(state) {
+    return { useReplaceToNavigate: true, data: state };
+  }
+
+  error(message) {
+    return { status: AuthenticationResultStatus.Fail, message };
+  }
+
+  success(state) {
+    return { status: AuthenticationResultStatus.Success, state };
+  }
+
+  redirect() {
+    return { status: AuthenticationResultStatus.Redirect };
+  }
+
+  async ensureUserManagerInitialized() {
+    if (this.userManager !== undefined) {
+      return;
     }
 
-    // We try to sign out the user in two different ways:
-    // 1) We try to do a sign-out using a PopUp Window. This might fail if there is a
-    //    Pop-Up blocker or the user has disabled PopUps.
-    // 2) If the method above fails, we redirect the browser to the IdP to perform a traditional
-    //    post logout redirect flow.
-    async signOut(state) {
-        await this.ensureUserManagerInitialized();
-        try {
-            if (this._popUpDisabled) {
-                throw new Error('Popup disabled. Change \'AuthorizeService.js:AuthorizeService._popupDisabled\' to false to enable it.')
-            }
-
-            await this.userManager.signoutPopup(this.createArguments());
-            this.updateState(undefined);
-            return this.success(state);
-        } catch (popupSignOutError) {
-            console.log("Popup signout error: ", popupSignOutError);
-            try {
-                await this.userManager.signoutRedirect(this.createArguments(state));
-                return this.redirect();
-            } catch (redirectSignOutError) {
-                console.log("Redirect signout error: ", redirectSignOutError);
-                return this.error(redirectSignOutError);
-            }
-        }
+    let response = await fetch(ApplicationPaths.ApiAuthorizationClientConfigurationUrl);
+    if (!response.ok) {
+      throw new Error(`Could not load settings for '${ApplicationName}'`);
     }
 
-    async completeSignOut(url) {
-        await this.ensureUserManagerInitialized();
-        try {
-            const response = await this.userManager.signoutCallback(url);
-            this.updateState(null);
-            return this.success(response && response.data);
-        } catch (error) {
-            console.log(`There was an error trying to log out '${error}'.`);
-            return this.error(error);
-        }
-    }
+    let settings = await response.json();
+    settings.automaticSilentRenew = true;
+    settings.includeIdTokenInSilentRenew = true;
+    settings.userStore = new WebStorageStateStore({
+      prefix: ApplicationName
+    });
 
-    updateState(user) {
-        this._user = user;
-        this._isAuthenticated = !!this._user;
-        this.notifySubscribers();
-    }
+    this.userManager = new UserManager(settings);
 
-    subscribe(callback) {
-        this._callbacks.push({ callback, subscription: this._nextSubscriptionId++ });
-        return this._nextSubscriptionId - 1;
-    }
+    this.userManager.events.addUserSignedOut(async () => {
+      await this.userManager.removeUser();
+      this.updateState(undefined);
+    });
+  }
 
-    unsubscribe(subscriptionId) {
-        const subscriptionIndex = this._callbacks
-            .map((element, index) => element.subscription === subscriptionId ? { found: true, index } : { found: false })
-            .filter(element => element.found === true);
-        if (subscriptionIndex.length !== 1) {
-            throw new Error(`Found an invalid number of subscriptions ${subscriptionIndex.length}`);
-        }
-
-        this._callbacks.splice(subscriptionIndex[0].index, 1);
-    }
-
-    notifySubscribers() {
-        for (let i = 0; i < this._callbacks.length; i++) {
-            const callback = this._callbacks[i].callback;
-            callback();
-        }
-    }
-
-    createArguments(state) {
-        return { useReplaceToNavigate: true, data: state };
-    }
-
-    error(message) {
-        return { status: AuthenticationResultStatus.Fail, message };
-    }
-
-    success(state) {
-        return { status: AuthenticationResultStatus.Success, state };
-    }
-
-    redirect() {
-        return { status: AuthenticationResultStatus.Redirect };
-    }
-
-    async ensureUserManagerInitialized() {
-        if (this.userManager !== undefined) {
-            return;
-        }
-
-        let response = await fetch(ApplicationPaths.ApiAuthorizationClientConfigurationUrl);
-        if (!response.ok) {
-            throw new Error(`Could not load settings for '${ApplicationName}'`);
-        }
-
-        let settings = await response.json();
-        settings.automaticSilentRenew = true;
-        settings.includeIdTokenInSilentRenew = true;
-        settings.userStore = new WebStorageStateStore({
-            prefix: ApplicationName
-        });
-
-        this.userManager = new UserManager(settings);
-
-        this.userManager.events.addUserSignedOut(async () => {
-            await this.userManager.removeUser();
-            this.updateState(undefined);
-        });
-    }
-
-    static get instance() { return authService }
+  static get instance() { return authService }
 }
 
 const authService = new AuthorizeService();
@@ -207,7 +207,7 @@ const authService = new AuthorizeService();
 export default authService;
 
 export const AuthenticationResultStatus = {
-    Redirect: 'redirect',
-    Success: 'success',
-    Fail: 'fail'
+  Redirect: 'redirect',
+  Success: 'success',
+  Fail: 'fail'
 };

--- a/src/content/React-CSharp/ClientApp/src/components/api-authorization/Login.js
+++ b/src/content/React-CSharp/ClientApp/src/components/api-authorization/Login.js
@@ -1,5 +1,5 @@
-import React from 'react'
-import { Component } from 'react';
+import React from 'react';
+import { useState, useEffect } from 'react';
 import authService from './AuthorizeService';
 import { AuthenticationResultStatus } from './AuthorizeService';
 import { LoginActions, QueryParameterNames, ApplicationPaths } from './ApiAuthorizationConstants';
@@ -8,126 +8,112 @@ import { LoginActions, QueryParameterNames, ApplicationPaths } from './ApiAuthor
 // This is the starting point for the login process. Any component that needs to authenticate
 // a user can simply perform a redirect to this component with a returnUrl query parameter and
 // let the component perform the login and return back to the return url.
-export class Login extends Component {
-    constructor(props) {
-        super(props);
+export function Login(props) {
+  const [message, setMessage] = useState(undefined);
 
-        this.state = {
-            message: undefined
-        };
-    }
+  useEffect(() => {
+    const processLoginCallback = async () => {
+      const url = window.location.href;
+      const result = await authService.completeSignIn(url);
+      switch (result.status) {
+        case AuthenticationResultStatus.Redirect:
+          // There should not be any redirects as the only time completeSignIn finishes
+          // is when we are doing a redirect sign in flow.
+          throw new Error('Should not redirect.');
+        case AuthenticationResultStatus.Success:
+          await navigateToReturnUrl(getReturnUrl(result.state));
+          break;
+        case AuthenticationResultStatus.Fail:
+          setMessage(result.message);
+          break;
+        default:
+          throw new Error(`Invalid authentication result status '${result.status}'.`);
+      }
+    };
 
-    componentDidMount() {
-        const action = this.props.action;
-        switch (action) {
-            case LoginActions.Login:
-                this.login(this.getReturnUrl());
-                break;
-            case LoginActions.LoginCallback:
-                this.processLoginCallback();
-                break;
-            case LoginActions.LoginFailed:
-                const params = new URLSearchParams(window.location.search);
-                const error = params.get(QueryParameterNames.Message);
-                this.setState({ message: error });
-                break;
-            case LoginActions.Profile:
-                this.redirectToProfile();
-                break;
-            case LoginActions.Register:
-                this.redirectToRegister();
-                break;
-            default:
-                throw new Error(`Invalid action '${action}'`);
-        }
-    }
+    const login = async (returnUrl) => {
+      const state = { returnUrl };
+      const result = await authService.signIn(state);
+      switch (result.status) {
+        case AuthenticationResultStatus.Redirect:
+          break;
+        case AuthenticationResultStatus.Success:
+          await navigateToReturnUrl(returnUrl);
+          break;
+        case AuthenticationResultStatus.Fail:
+          setMessage(result.message);
+          break;
+        default:
+          throw new Error(`Invalid status result ${result.status}.`);
+      }
+    };
 
-    render() {
-        const action = this.props.action;
-        const { message } = this.state;
-
-        if (!!message) {
-            return <div>{message}</div>
-        } else {
-            switch (action) {
-                case LoginActions.Login:
-                    return (<div>Processing login</div>);
-                case LoginActions.LoginCallback:
-                    return (<div>Processing login callback</div>);
-                case LoginActions.Profile:
-                case LoginActions.Register:
-                    return (<div></div>);
-                default:
-                    throw new Error(`Invalid action '${action}'`);
-            }
-        }
-    }
-
-    async login(returnUrl) {
-        const state = { returnUrl };
-        const result = await authService.signIn(state);
-        switch (result.status) {
-            case AuthenticationResultStatus.Redirect:
-                break;
-            case AuthenticationResultStatus.Success:
-                await this.navigateToReturnUrl(returnUrl);
-                break;
-            case AuthenticationResultStatus.Fail:
-                this.setState({ message: result.message });
-                break;
-            default:
-                throw new Error(`Invalid status result ${result.status}.`);
-        }
-    }
-
-    async processLoginCallback() {
-        const url = window.location.href;
-        const result = await authService.completeSignIn(url);
-        switch (result.status) {
-            case AuthenticationResultStatus.Redirect:
-                // There should not be any redirects as the only time completeSignIn finishes
-                // is when we are doing a redirect sign in flow.
-                throw new Error('Should not redirect.');
-            case AuthenticationResultStatus.Success:
-                await this.navigateToReturnUrl(this.getReturnUrl(result.state));
-                break;
-            case AuthenticationResultStatus.Fail:
-                this.setState({ message: result.message });
-                break;
-            default:
-                throw new Error(`Invalid authentication result status '${result.status}'.`);
-        }
-    }
-
-    getReturnUrl(state) {
+    const redirectToRegister = () => redirectToApiAuthorizationPath(`${ApplicationPaths.IdentityRegisterPath}?${QueryParameterNames.ReturnUrl}=${encodeURI(ApplicationPaths.Login)}`);
+    const redirectToProfile = () => redirectToApiAuthorizationPath(ApplicationPaths.IdentityManagePath);
+    
+    const action = props.action;
+    switch (action) {
+      case LoginActions.Login:
+        login(getReturnUrl());
+        break;
+      case LoginActions.LoginCallback:
+        processLoginCallback();
+        break;
+      case LoginActions.LoginFailed:
         const params = new URLSearchParams(window.location.search);
-        const fromQuery = params.get(QueryParameterNames.ReturnUrl);
-        if (fromQuery && !fromQuery.startsWith(`${window.location.origin}/`)) {
-            // This is an extra check to prevent open redirects.
-            throw new Error("Invalid return url. The return url needs to have the same origin as the current page.")
-        }
-        return (state && state.returnUrl) || fromQuery || `${window.location.origin}/`;
+        const error = params.get(QueryParameterNames.Message);
+        setMessage(error);
+        break;
+      case LoginActions.Profile:
+        redirectToProfile();
+        break;
+      case LoginActions.Register:
+        redirectToRegister();
+        break;
+      default:
+        throw new Error(`Invalid action '${action}'`);
     }
+  }, [])
 
-    redirectToRegister() {
-        this.redirectToApiAuthorizationPath(`${ApplicationPaths.IdentityRegisterPath}?${QueryParameterNames.ReturnUrl}=${encodeURI(ApplicationPaths.Login)}`);
+  const getReturnUrl = (state) => {
+    const params = new URLSearchParams(window.location.search);
+    const fromQuery = params.get(QueryParameterNames.ReturnUrl);
+    if (fromQuery && !fromQuery.startsWith(`${window.location.origin}/`)) {
+      // This is an extra check to prevent open redirects.
+      throw new Error("Invalid return url. The return url needs to have the same origin as the current page.")
     }
+    return (state && state.returnUrl) || fromQuery || `${window.location.origin}/`;
+  }
 
-    redirectToProfile() {
-        this.redirectToApiAuthorizationPath(ApplicationPaths.IdentityManagePath);
-    }
+  const redirectToApiAuthorizationPath = (apiAuthorizationPath) => {
+    const redirectUrl = `${window.location.origin}/${apiAuthorizationPath}`;
+    // It's important that we do a replace here so that when the user hits the back arrow on the
+    // browser they get sent back to where it was on the app instead of to an endpoint on this
+    // component.
+    window.location.replace(redirectUrl);
+  }
 
-    redirectToApiAuthorizationPath(apiAuthorizationPath) {
-        const redirectUrl = `${window.location.origin}/${apiAuthorizationPath}`;
-        // It's important that we do a replace here so that when the user hits the back arrow on the
-        // browser they get sent back to where it was on the app instead of to an endpoint on this
-        // component.
-        window.location.replace(redirectUrl);
-    }
+  const navigateToReturnUrl = (returnUrl) => {
+    // It's important that we do a replace here so that we remove the callback uri with the
+    // fragment containing the tokens from the browser history.
+    window.location.replace(returnUrl);
+  }
 
-    navigateToReturnUrl(returnUrl) {
-        // It's important that we do a replace here so that we remove the callback uri with the
-        // fragment containing the tokens from the browser history.
-        window.location.replace(returnUrl);
+  const action = props.action;
+
+  if (!!message) {
+    return <div>{message}</div>
+  } else {
+    switch (action) {
+      case LoginActions.Login:
+        return (<div>Processing login</div>);
+      case LoginActions.LoginCallback:
+        return (<div>Processing login callback</div>);
+      case LoginActions.Profile:
+      case LoginActions.Register:
+        return (<div/>);
+      default:
+        throw new Error(`Invalid action '${action}'`);
     }
+  }
 }

--- a/src/content/React-CSharp/ClientApp/src/components/api-authorization/LoginMenu.js
+++ b/src/content/React-CSharp/ClientApp/src/components/api-authorization/LoginMenu.js
@@ -1,69 +1,53 @@
-import React, { Component, Fragment } from 'react';
+import React from 'react';
+import { useState, useEffect, Fragment } from 'react';
 import { NavItem, NavLink } from 'reactstrap';
 import { Link } from 'react-router-dom';
 import authService from './AuthorizeService';
 import { ApplicationPaths } from './ApiAuthorizationConstants';
 
-export class LoginMenu extends Component {
-    constructor(props) {
-        super(props);
+export function LoginMenu() {
+  const [isAuthenticated, setIsAuthenticated] = useState(false);
+  const [userName, setUserName] = useState(null);
 
-        this.state = {
-            isAuthenticated: false,
-            userName: null
-        };
-    }
+  useEffect(() => {
+    const populateState = async () => {
+      const [isAuthenticated, user] = await Promise.all([authService.isAuthenticated(), authService.getUser()])
+      setIsAuthenticated(isAuthenticated);
+      setUserName(user && user.name);
+    };
 
-    componentDidMount() {
-        this._subscription = authService.subscribe(() => this.populateState());
-        this.populateState();
-    }
+    const subscription = authService.subscribe(() => populateState());
+    populateState();
+    return () => authService.unsubscribe(subscription);
+  }, [])
 
-    componentWillUnmount() {
-        authService.unsubscribe(this._subscription);
-    }
+  const authenticatedView = (userName, profilePath, logoutPath) => (
+    <Fragment>
+      <NavItem>
+        <NavLink tag={Link} className="text-dark" to={profilePath}>Hello {userName}</NavLink>
+      </NavItem>
+      <NavItem>
+        <NavLink tag={Link} className="text-dark" to={logoutPath}>Logout</NavLink>
+      </NavItem>
+    </Fragment>);
 
-    async populateState() {
-        const [isAuthenticated, user] = await Promise.all([authService.isAuthenticated(), authService.getUser()])
-        this.setState({
-            isAuthenticated,
-            userName: user && user.name
-        });
-    }
+  const anonymousView = (registerPath, loginPath) => (
+    <Fragment>
+      <NavItem>
+        <NavLink tag={Link} className="text-dark" to={registerPath}>Register</NavLink>
+      </NavItem>
+      <NavItem>
+        <NavLink tag={Link} className="text-dark" to={loginPath}>Login</NavLink>
+      </NavItem>
+    </Fragment>);
 
-    render() {
-        const { isAuthenticated, userName } = this.state;
-        if (!isAuthenticated) {
-            const registerPath = `${ApplicationPaths.Register}`;
-            const loginPath = `${ApplicationPaths.Login}`;
-            return this.anonymousView(registerPath, loginPath);
-        } else {
-            const profilePath = `${ApplicationPaths.Profile}`;
-            const logoutPath = { pathname: `${ApplicationPaths.LogOut}`, state: { local: true } };
-            return this.authenticatedView(userName, profilePath, logoutPath);
-        }
-    }
-
-    authenticatedView(userName, profilePath, logoutPath) {
-        return (<Fragment>
-            <NavItem>
-                <NavLink tag={Link} className="text-dark" to={profilePath}>Hello {userName}</NavLink>
-            </NavItem>
-            <NavItem>
-                <NavLink tag={Link} className="text-dark" to={logoutPath}>Logout</NavLink>
-            </NavItem>
-        </Fragment>);
-
-    }
-
-    anonymousView(registerPath, loginPath) {
-        return (<Fragment>
-            <NavItem>
-                <NavLink tag={Link} className="text-dark" to={registerPath}>Register</NavLink>
-            </NavItem>
-            <NavItem>
-                <NavLink tag={Link} className="text-dark" to={loginPath}>Login</NavLink>
-            </NavItem>
-        </Fragment>);
-    }
+  if (!isAuthenticated) {
+    const registerPath = `${ApplicationPaths.Register}`;
+    const loginPath = `${ApplicationPaths.Login}`;
+    return anonymousView(registerPath, loginPath);
+  } else {
+    const profilePath = `${ApplicationPaths.Profile}`;
+    const logoutPath = { pathname: `${ApplicationPaths.LogOut}`, state: { local: true } };
+    return authenticatedView(userName, profilePath, logoutPath);
+  }
 }

--- a/src/content/React-CSharp/ClientApp/src/components/api-authorization/Logout.js
+++ b/src/content/React-CSharp/ClientApp/src/components/api-authorization/Logout.js
@@ -1,5 +1,5 @@
-import React from 'react'
-import { Component } from 'react';
+import React from 'react';
+import { useState, useEffect } from 'react';
 import authService from './AuthorizeService';
 import { AuthenticationResultStatus } from './AuthorizeService';
 import { QueryParameterNames, LogoutActions, ApplicationPaths } from './ApiAuthorizationConstants';
@@ -7,122 +7,107 @@ import { QueryParameterNames, LogoutActions, ApplicationPaths } from './ApiAutho
 // The main responsibility of this component is to handle the user's logout process.
 // This is the starting point for the logout process, which is usually initiated when a
 // user clicks on the logout button on the LoginMenu component.
-export class Logout extends Component {
-    constructor(props) {
-        super(props);
+export function Logout(props) {
+  const [message, setMessage] = useState(undefined);
+  const [isReady, setIsReady] = useState(false);
 
-        this.state = {
-            message: undefined,
-            isReady: false,
-            authenticated: false
-        };
-    }
-
-    componentDidMount() {
-        const action = this.props.action;
-        switch (action) {
-            case LogoutActions.Logout:
-                if (!!window.history.state.state.local) {
-                    this.logout(this.getReturnUrl());
-                } else {
-                    // This prevents regular links to <app>/authentication/logout from triggering a logout
-                    this.setState({ isReady: true, message: "The logout was not initiated from within the page." });
-                }
-                break;
-            case LogoutActions.LogoutCallback:
-                this.processLogoutCallback();
-                break;
-            case LogoutActions.LoggedOut:
-                this.setState({ isReady: true, message: "You successfully logged out!" });
-                break;
-            default:
-                throw new Error(`Invalid action '${action}'`);
-        }
-
-        this.populateAuthenticationState();
-    }
-
-    render() {
-        const { isReady, message } = this.state;
-        if (!isReady) {
-            return <div></div>
-        }
-        if (!!message) {
-            return (<div>{message}</div>);
-        } else {
-            const action = this.props.action;
-            switch (action) {
-                case LogoutActions.Logout:
-                    return (<div>Processing logout</div>);
-                case LogoutActions.LogoutCallback:
-                    return (<div>Processing logout callback</div>);
-                case LogoutActions.LoggedOut:
-                    return (<div>{message}</div>);
-                default:
-                    throw new Error(`Invalid action '${action}'`);
-            }
-        }
-    }
-
-    async logout(returnUrl) {
-        const state = { returnUrl };
-        const isauthenticated = await authService.isAuthenticated();
-        if (isauthenticated) {
-            const result = await authService.signOut(state);
-            switch (result.status) {
-                case AuthenticationResultStatus.Redirect:
-                    break;
-                case AuthenticationResultStatus.Success:
-                    await this.navigateToReturnUrl(returnUrl);
-                    break;
-                case AuthenticationResultStatus.Fail:
-                    this.setState({ message: result.message });
-                    break;
-                default:
-                    throw new Error("Invalid authentication result status.");
-            }
-        } else {
-            this.setState({ message: "You successfully logged out!" });
-        }
-    }
-
-    async processLogoutCallback() {
-        const url = window.location.href;
-        const result = await authService.completeSignOut(url);
+  useEffect(() => {
+    const processLogoutCallback = async () => {
+      const url = window.location.href;
+      const result = await authService.completeSignOut(url);
+      switch (result.status) {
+        case AuthenticationResultStatus.Redirect:
+          // There should not be any redirects as the only time completeAuthentication finishes
+          // is when we are doing a redirect sign in flow.
+          throw new Error('Should not redirect.');
+        case AuthenticationResultStatus.Success:
+          await navigateToReturnUrl(getReturnUrl(result.state));
+          break;
+        case AuthenticationResultStatus.Fail:
+          setMessage(result.message);
+          break;
+        default:
+          throw new Error("Invalid authentication result status.");
+      }
+    };
+    
+    const logout = async (returnUrl) => {
+      const state = { returnUrl };
+      const isAuthenticated = await authService.isAuthenticated();
+      if (isAuthenticated) {
+        const result = await authService.signOut(state);
         switch (result.status) {
-            case AuthenticationResultStatus.Redirect:
-                // There should not be any redirects as the only time completeAuthentication finishes
-                // is when we are doing a redirect sign in flow.
-                throw new Error('Should not redirect.');
-            case AuthenticationResultStatus.Success:
-                await this.navigateToReturnUrl(this.getReturnUrl(result.state));
-                break;
-            case AuthenticationResultStatus.Fail:
-                this.setState({ message: result.message });
-                break;
-            default:
-                throw new Error("Invalid authentication result status.");
+          case AuthenticationResultStatus.Redirect:
+            break;
+          case AuthenticationResultStatus.Success:
+            await navigateToReturnUrl(returnUrl);
+            break;
+          case AuthenticationResultStatus.Fail:
+            setMessage(result.message);
+            break;
+          default:
+            throw new Error("Invalid authentication result status.");
         }
-    }
-
-    async populateAuthenticationState() {
-        const authenticated = await authService.isAuthenticated();
-        this.setState({ isReady: true, authenticated });
-    }
-
-    getReturnUrl(state) {
-        const params = new URLSearchParams(window.location.search);
-        const fromQuery = params.get(QueryParameterNames.ReturnUrl);
-        if (fromQuery && !fromQuery.startsWith(`${window.location.origin}/`)) {
-            // This is an extra check to prevent open redirects.
-            throw new Error("Invalid return url. The return url needs to have the same origin as the current page.")
+      } else {
+        setMessage("You successfully logged out!");
+      }
+    };
+    
+    const action = props.action;
+    switch (action) {
+      case LogoutActions.Logout:
+        if (!!window.history.state.state.local) {
+          logout(getReturnUrl());
+        } else {
+          // This prevents regular links to <app>/authentication/logout from triggering a logout
+          setIsReady(true);
+          setMessage("The logout was not initiated from within the page.");
         }
-        return (state && state.returnUrl) ||
-            fromQuery ||
-            `${window.location.origin}${ApplicationPaths.LoggedOut}`;
+        break;
+      case LogoutActions.LogoutCallback:
+        processLogoutCallback();
+        break;
+      case LogoutActions.LoggedOut:
+        setIsReady(true);
+        setMessage("You successfully logged out!");
+        break;
+      default:
+        throw new Error(`Invalid action '${action}'`);
     }
 
-    navigateToReturnUrl(returnUrl) {
-        return window.location.replace(returnUrl);
+    setIsReady(true);
+  }, [props])
+
+  const getReturnUrl = (state) => {
+    const params = new URLSearchParams(window.location.search);
+    const fromQuery = params.get(QueryParameterNames.ReturnUrl);
+    if (fromQuery && !fromQuery.startsWith(`${window.location.origin}/`)) {
+      // This is an extra check to prevent open redirects.
+      throw new Error("Invalid return url. The return url needs to have the same origin as the current page.")
     }
+    return (state && state.returnUrl) ||
+      fromQuery ||
+      `${window.location.origin}${ApplicationPaths.LoggedOut}`;
+  }
+
+  const navigateToReturnUrl = (returnUrl) => window.location.replace(returnUrl);
+
+  if (!isReady) {
+    return <div/>
+  }
+  if (!!message) {
+    return (<div>{message}</div>);
+  } else {
+    const action = props.action;
+    switch (action) {
+      case LogoutActions.Logout:
+        return (<div>Processing logout</div>);
+      case LogoutActions.LogoutCallback:
+        return (<div>Processing logout callback</div>);
+      case LogoutActions.LoggedOut:
+        return (<div>{message}</div>);
+      default:
+        throw new Error(`Invalid action '${action}'`);
+    }
+  }
 }

--- a/src/content/React-CSharp/ClientApp/src/components/api-authorization/Logout.js
+++ b/src/content/React-CSharp/ClientApp/src/components/api-authorization/Logout.js
@@ -76,7 +76,7 @@ export function Logout(props) {
     }
 
     setIsReady(true);
-  }, [props])
+  }, [])
 
   const getReturnUrl = (state) => {
     const params = new URLSearchParams(window.location.search);

--- a/src/content/React-CSharp/ClientApp/src/index.js
+++ b/src/content/React-CSharp/ClientApp/src/index.js
@@ -2,7 +2,7 @@ import 'bootstrap/dist/css/bootstrap.css';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { BrowserRouter } from 'react-router-dom';
-import App from './App';
+import { App } from './App';
 import * as serviceWorkerRegistration from './serviceWorkerRegistration';
 import reportWebVitals from './reportWebVitals';
 


### PR DESCRIPTION
This pr based on [issue from aspnetcore repository](https://github.com/dotnet/aspnetcore/issues/40540).

I rewrote react template components including authorization components in functional style with hooks. 
useEffect with empty DependencyList were used instead of componentDidMount and  componentWillUnmount.

Some import statements in components some lines contained a semicolon at the end and others did not. Now all imports have a semicolon at the end of the line. Also some imports for 'react' contained both namespace and components imports and others were separated to two imports. Now all imports for react are separated.

Components in main part of template and api-authorization had different indents. It also unified in this PR.

Fixes https://github.com/dotnet/aspnetcore/issues/40540