### PR TITLE
Fix UseProgramMain template option in VS

### DIFF
--- a/src/content/Angular-CSharp/.template.config/template.json
+++ b/src/content/Angular-CSharp/.template.config/template.json
@@ -285,6 +285,7 @@
       "type": "parameter",
       "datatype": "bool",
       "defaultValue": "false",
+      "displayName": "Do not use top-level statements",
       "description": "Whether to generate an explicit Program class and Main method instead of top-level statements."
     }
   },

--- a/src/content/Angular-CSharp/.template.config/vs-2017.3.host.json
+++ b/src/content/Angular-CSharp/.template.config/vs-2017.3.host.json
@@ -41,13 +41,7 @@
   "symbolInfo": [
     {
       "id": "UseProgramMain",
-      "name": {
-        "text": "Use top-level statements (uncheck to use an explicit Program class with a Main method)",
-        "overrideDefaultText": true
-      },
-      "invertBoolean": true,
-      "isVisible": true,
-      "defaultValue": true
+      "isVisible": true
     }
   ],
   "excludeLaunchSettings": false,

--- a/src/content/React-CSharp/.template.config/template.json
+++ b/src/content/React-CSharp/.template.config/template.json
@@ -287,6 +287,7 @@
       "type": "parameter",
       "datatype": "bool",
       "defaultValue": "false",
+      "displayName": "Do not use top-level statements",
       "description": "Whether to generate an explicit Program class and Main method instead of top-level statements."
     }
   },

--- a/src/content/React-CSharp/.template.config/vs-2017.3.host.json
+++ b/src/content/React-CSharp/.template.config/vs-2017.3.host.json
@@ -41,13 +41,7 @@
   "symbolInfo": [
     {
       "id": "UseProgramMain",
-      "name": {
-        "text": "Use top-level statements (uncheck to use an explicit Program class with a Main method)",
-        "overrideDefaultText": true
-      },
-      "invertBoolean": true,
-      "isVisible": true,
-      "defaultValue": true
+      "isVisible": true
     }
   ],
   "excludeLaunchSettings": false,


### PR DESCRIPTION
Tweak to how the option shows up in VS to avoid localization complexities and align with text used in other templates.

Fixes #40917