### PR TITLE
Fix broken WebSocket support

### DIFF
--- a/src/content/React-CSharp/ClientApp/src/setupProxy.js
+++ b/src/content/React-CSharp/ClientApp/src/setupProxy.js
@@ -27,12 +27,22 @@ module.exports = function (app) {
     // the ASP NET Core webserver is unavailable
     onError: onError,
     secure: false,
-    // Uncomment this line to add support for proxying websockets
-    //ws: true, 
     headers: {
       Connection: 'Keep-Alive'
     }
   });
 
   app.use(appProxy);
+  
+  // Uncomment these lines to add support for proxying WebSockets
+  /*
+  const wsProxy = createProxyMiddleware('/ws', {
+    target: target,
+    onError: onError,
+    secure: false,
+    ws: true
+  });
+  
+  app.use(wsProxy);
+  */
 };


### PR DESCRIPTION
When the `Connection: 'Keep-Alive'` header is sent the `HttpContext.WebSockets.IsWebSocketRequest` will always be `false`.