### PR TITLE
Enable applying AuthorizeGuard to empty route

### DIFF
--- a/src/content/Angular-CSharp/ClientApp/src/api-authorization/login/login.component.ts
+++ b/src/content/Angular-CSharp/ClientApp/src/api-authorization/login/login.component.ts
@@ -105,7 +105,7 @@ export class LoginComponent implements OnInit {
     // a relative url or an absolute url
     if (fromQuery &&
       !(fromQuery.startsWith(`${window.location.origin}/`) ||
-        /\/[^\/].*/.test(fromQuery))) {
+        /\/[^\/]?.*/.test(fromQuery))) {
       // This is an extra check to prevent open redirects.
       throw new Error('Invalid return url. The return url needs to have the same origin as the current page.');
     }


### PR DESCRIPTION
If the root route activates AuthorizeGuard then the redirect
would fail because the regex checking for valid returnUrl-s
does not match on `/`