### PR TITLE
Improve multi-stage image build support.

### DIFF
--- a/src/Angular-CSharp.csproj.in
+++ b/src/Angular-CSharp.csproj.in
@@ -7,9 +7,11 @@
     <NoDefaultLaunchSettingsFile Condition="'$(ExcludeLaunchSettings)' == 'True'">True</NoDefaultLaunchSettingsFile>
 <!--#if (!NoSpaFrontEnd) -->
     <SpaRoot>ClientApp\</SpaRoot>
+    <SpaInstallCommand>npm install</SpaInstallCommand>
+    <SpaBuildCommand>npm run build</SpaBuildCommand>
+    <SpaProxyLaunchCommand>npm start</SpaProxyLaunchCommand>
     <SpaProxyServerUrl Condition="'$(RequiresHttps)' == 'True'">https://localhost:5002</SpaProxyServerUrl>
     <SpaProxyServerUrl Condition="'$(RequiresHttps)' != 'True'">http://localhost:5002</SpaProxyServerUrl>
-    <SpaProxyLaunchCommand>npm start</SpaProxyLaunchCommand>
 <!--#endif -->
     <RootNamespace Condition="'$(name)' != '$(name{-VALUE-FORMS-}safe_namespace)'">Company.WebApplication1</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>
@@ -46,14 +48,14 @@
     </Exec>
     <Error Condition="'$(ErrorCode)' != '0'" Text="Node.js is required to build and run this project. To continue, please install Node.js from https://nodejs.org/, and then restart your command prompt or IDE." />
     <Message Importance="high" Text="Restoring dependencies using 'npm'. This may take several minutes..." />
-    <Exec WorkingDirectory="$(SpaRoot)" Command="npm install" />
+    <Exec WorkingDirectory="$(SpaRoot)" Command="$(SpaInstallCommand)" />
   </Target>
   <!--/+:cnd:noEmit -->
 
   <Target Name="PublishRunWebpack" AfterTargets="ComputeFilesToPublish">
     <!-- As part of publishing, ensure the JS resources are freshly built in production mode -->
-    <Exec WorkingDirectory="$(SpaRoot)" Command="npm install" />
-    <Exec WorkingDirectory="$(SpaRoot)" Command="npm run build -- --configuration production" />
+    <Exec WorkingDirectory="$(SpaRoot)" Command="$(SpaInstallCommand)" Condition="'$(SkipSpaBuild)' != 'True'" />
+    <Exec WorkingDirectory="$(SpaRoot)" Command="$(SpaBuildCommand)" Condition="'$(SkipSpaBuild)' != 'True'" />
 
     <!-- Include the newly-built files in the publish output -->
     <ItemGroup>

--- a/src/Angular-CSharp.csproj.in
+++ b/src/Angular-CSharp.csproj.in
@@ -54,6 +54,7 @@
 
   <Target Name="PublishRunWebpack" AfterTargets="ComputeFilesToPublish">
     <!-- As part of publishing, ensure the JS resources are freshly built in production mode -->
+    <SkipSpaBuild Condition="'$(DOTNET_RUNNING_IN_CONTAINER)' == 'true'">True</SkipSpaBuild>
     <Exec WorkingDirectory="$(SpaRoot)" Command="$(SpaInstallCommand)" Condition="'$(SkipSpaBuild)' != 'True'" />
     <Exec WorkingDirectory="$(SpaRoot)" Command="$(SpaBuildCommand)" Condition="'$(SkipSpaBuild)' != 'True'" />
 

--- a/src/React-CSharp.csproj.in
+++ b/src/React-CSharp.csproj.in
@@ -57,6 +57,7 @@
 
   <Target Name="PublishRunWebpack" AfterTargets="ComputeFilesToPublish">
     <!-- As part of publishing, ensure the JS resources are freshly built in production mode -->
+    <SkipSpaBuild Condition="'$(DOTNET_RUNNING_IN_CONTAINER)' == 'true'">True</SkipSpaBuild>
     <Exec WorkingDirectory="$(SpaRoot)" Command="$(SpaInstallCommand)" Condition="'$(SkipSpaBuild)' != 'True'" />
     <Exec WorkingDirectory="$(SpaRoot)" Command="$(SpaBuildCommand)" Condition="'$(SkipSpaBuild)' != 'True'" />
 

--- a/src/React-CSharp.csproj.in
+++ b/src/React-CSharp.csproj.in
@@ -9,10 +9,12 @@
     <NoDefaultLaunchSettingsFile Condition="'$(ExcludeLaunchSettings)' == 'True'">True</NoDefaultLaunchSettingsFile>
 <!--#if (!NoSpaFrontEnd) -->
     <SpaRoot>ClientApp\</SpaRoot>
+    <SpaInstallCommand>npm install</SpaInstallCommand>
+    <SpaBuildCommand>npm run build</SpaBuildCommand>
+    <SpaProxyLaunchCommand>npm start</SpaProxyLaunchCommand>
     <DefaultItemExcludes>$(DefaultItemExcludes);$(SpaRoot)node_modules\**</DefaultItemExcludes>
     <SpaProxyServerUrl Condition="'$(RequiresHttps)' == 'True'">https://localhost:5002</SpaProxyServerUrl>
     <SpaProxyServerUrl Condition="'$(RequiresHttps)' != 'True'">http://localhost:5002</SpaProxyServerUrl>
-    <SpaProxyLaunchCommand>npm start</SpaProxyLaunchCommand>
 <!--#endif -->
     <RootNamespace Condition="'$(name)' != '$(name{-VALUE-FORMS-}safe_namespace)'">Company.WebApplication1</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>
@@ -49,14 +51,14 @@
     </Exec>
     <Error Condition="'$(ErrorCode)' != '0'" Text="Node.js is required to build and run this project. To continue, please install Node.js from https://nodejs.org/, and then restart your command prompt or IDE." />
     <Message Importance="high" Text="Restoring dependencies using 'npm'. This may take several minutes..." />
-    <Exec WorkingDirectory="$(SpaRoot)" Command="npm install" />
+    <Exec WorkingDirectory="$(SpaRoot)" Command="$(SpaInstallCommand)" />
   </Target>
 <!--/+:cnd:noEmit -->
 
   <Target Name="PublishRunWebpack" AfterTargets="ComputeFilesToPublish">
     <!-- As part of publishing, ensure the JS resources are freshly built in production mode -->
-    <Exec WorkingDirectory="$(SpaRoot)" Command="npm install" />
-    <Exec WorkingDirectory="$(SpaRoot)" Command="npm run build" />
+    <Exec WorkingDirectory="$(SpaRoot)" Command="$(SpaInstallCommand)" Condition="'$(SkipSpaBuild)' != 'True'" />
+    <Exec WorkingDirectory="$(SpaRoot)" Command="$(SpaBuildCommand)" Condition="'$(SkipSpaBuild)' != 'True'" />
 
     <!-- Include the newly-built files in the publish output -->
     <ItemGroup>


### PR DESCRIPTION
Make it possible to opt-out of the nodejs frontend build when the .NET backend gets build.

This allows to build the frontend and backend in separate build stages.

Fixes https://github.com/dotnet/aspnetcore/issues/41275.

@javiercn @richlander ptal.