### PR TITLE
Add synchronization of eng/common/

### DIFF
--- a/.github/workflows/CopyToTarget.cmd
+++ b/.github/workflows/CopyToTarget.cmd
@@ -1,0 +1,19 @@
+@ECHO OFF
+SETLOCAL
+
+IF NOT [%1] == [] (set from=%1)
+IF [%from%] == [] (
+  echo The 'from' command line parameter is not set, aborting.
+  exit /b 1
+)
+
+IF NOT [%2] == [] (set to=%2)
+IF [%to%] == [] (
+  echo The 'to' command line parameter is not set, aborting.
+  exit /b 1
+)
+
+echo Copying from '%from%' to '%to'.
+
+REM https://superuser.com/questions/280425/getting-robocopy-to-return-a-proper-exit-code
+(robocopy %from% %to% /MIR) ^& IF %ERRORLEVEL% LSS 8 SET ERRORLEVEL = 0

--- a/.github/workflows/ReportDiff.ps1
+++ b/.github/workflows/ReportDiff.ps1
@@ -1,0 +1,19 @@
+# Check the code is in sync
+$changed = (select-string "nothing to commit" artifacts\status.txt).count -eq 0
+if (-not $changed) { return $changed }
+
+# Check if there's an open PR in the target repo to resolve this difference.
+$sendpr = $true
+$Headers = @{ Accept = 'application/vnd.github.v3+json' };
+
+$prsLink = "https://api.github.com/repos/${env:TargetRepo}/pulls?state=open"
+$result = Invoke-RestMethod -Method GET -Headers $Headers -Uri $prsLink
+
+foreach ($pr in $result) {
+  if ($pr.body -And $pr.title.Contains("Sync shared code from ${env.TargetRepoName}")) {
+    $sendpr = $false
+    return $sendpr
+  }
+}
+
+return $sendpr

--- a/.github/workflows/arcade-sync.yml
+++ b/.github/workflows/arcade-sync.yml
@@ -1,0 +1,79 @@
+env:
+  PathToSynchronize: eng\common
+  SourceRepo: dotnet/arcade
+  SourceRepoName: arcade
+  TargetRepo: dotnet/spa-templates
+  TargetRepoName: spa-templates
+
+name: Code Sync
+
+on:
+  # Manual run
+  workflow_dispatch:
+  schedule:
+    # * is a special character in YAML so you have to quote this string
+    # https://help.github.com/en/actions/automating-your-workflow-with-github-actions/events-that-trigger-workflows#scheduled-events-schedule
+    # Once per week at midnight PST (8 UTC) on Monday.
+    - cron: '0 8 * * MON'
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  compare_repos:
+    # Comment out this line to test the scripts in a fork
+    if: ${{ github.repository == env.TargetRepo }}
+    name: "Compare the shared code in the given repos; open a PR in the target if they're out of sync."
+    runs-on: windows-latest
+    steps:
+    - name: Checkout ${{ env.SourceRepoName }}
+      uses: actions/checkout@v3
+      with:
+        repository: ${{ env.SourceRepo }}
+        path: ${{ env.SourceRepoName }}
+        ref: main
+    - name: Checkout ${{ env.TargetRepoName }}
+      uses: actions/checkout@v3
+      with:
+        repository: ${{ env.TargetRepo }}
+        path: ${{ env.TargetRepoName }}
+        ref: main
+    - name: Copy
+      shell: cmd
+      run: ${{ github.workspace }}\${{ env.TargetRepoName }}\.github\workflows\CopyToTarget.cmd
+        ${{ github.workspace }}\${{ env.SourceRepoName }}\${{ env.PathToSynchronize }}
+        ${{ github.workspace }}\${{ env.TargetRepoName }}\${{ env.PathToSynchronize }}
+    - name: Diff
+      shell: cmd
+      working-directory: ${{ github.workspace }}\${{ env.TargetRepoName }}
+      run: |
+        mkdir ..\artifacts
+        git status > ..\artifacts\status.txt
+        git diff > ..\artifacts\diff.txt
+    - uses: actions/upload-artifact@v3
+      with:
+        name: results
+        path: artifacts
+    - name: Check and Notify
+      id: check
+      shell: pwsh
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        $sendpr = ${{ github.workspace }}\${{ env.TargetRepoName }}\.github\workflows\ReportDiff.ps1
+        echo "::set-output name=sendpr::$sendpr"
+    - name: Send PR
+      if: steps.check.outputs.sendpr == 'true'
+      # https://github.com/marketplace/actions/create-pull-request
+      uses: dotnet/actions-create-pull-request@v3
+      with:
+        base: main
+        body: 'This PR was automatically generated to sync shared code changes from ${{ env.SourceRepoName }}.'
+        branch-suffix: timestamp
+        branch: github-action/sync-${{ env.SourceRepoName }}
+        commit-message: "Sync shared code from ${{ env.SourceRepoName }}"
+        labels: area-infrastructure
+        path: .\${{ env.TargetRepoName }}
+        title: 'Sync shared code from ${{ env.SourceRepoName }}'
+        token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
- keep files needed for `spa-templates-localization` pipeline up to date
- step 2/4 (yeah, not just of 3) for dotnet/aspnetcore#36998 in this repo
- copied from the runtime synchronization in dotnet/aspnetcore but simplified
  - work in only one direction
    - avoid needing an issue to coordinate sync in both directions
  - put the repo names in environment variables for use in the scripts