### PR TITLE
Prevent multiple `checksession` iframes

### DIFF
--- a/src/content/Angular-CSharp/ClientApp/src/api-authorization/authorize.service.ts
+++ b/src/content/Angular-CSharp/ClientApp/src/api-authorization/authorize.service.ts
@@ -43,6 +43,7 @@ export class AuthorizeService {
   private popUpDisabled = true;
   private userManager?: UserManager;
   private userSubject: BehaviorSubject<IUser | null> = new BehaviorSubject<IUser | null>(null);
+  private ensureUserManagerInitializedPromise?: Promise<void>;
 
   public isAuthenticated(): Observable<boolean> {
     return this.getUser().pipe(map(u => !!u));
@@ -170,7 +171,15 @@ export class AuthorizeService {
   }
 
   private async ensureUserManagerInitialized(): Promise<void> {
-    this.userManager ??= await this.createUserManager();
+    const ensureUserManagerInitializedInternal = async (): Promise<void> => {
+      this.userManager ??= await this.createUserManager();
+    };
+
+    if(!this.ensureUserManagerInitializedPromise) {
+      this.ensureUserManagerInitializedPromise = ensureUserManagerInitializedInternal();
+    }
+
+    return this.ensureUserManagerInitializedPromise;
   }
 
   private async createUserManager(): Promise<UserManager> {


### PR DESCRIPTION
This PR solves an issue where multiple `checksession` iframes are created.

This happens because every method in the *Authorize* service first calls `ensureUserManagerInitialized`, and this function first checks if the member `userManager` is truthy before continuing. However this function is not truly reentrant, because of `async` and multiple calls to it can pass over the `userManager` truthy check.

The solution involves wrapping the original function, and making sure the internal function is only called once, by promoting the truthy check up from the `userManager` to the promise of initializing it.