### PR TITLE
Added proxyTimeout to react and angular templates

### DIFF
--- a/src/content/Angular-CSharp/ClientApp/proxy.conf.js
+++ b/src/content/Angular-CSharp/ClientApp/proxy.conf.js
@@ -16,6 +16,7 @@ const PROXY_CONFIG = [
       "/_framework"
 //#endif
    ],
+    proxyTimeout: 3000,
     target: target,
     secure: false,
     headers: {

--- a/src/content/React-CSharp/ClientApp/src/setupProxy.js
+++ b/src/content/React-CSharp/ClientApp/src/setupProxy.js
@@ -22,6 +22,7 @@ const onError = (err, req, resp, target) => {
 
 module.exports = function (app) {
   const appProxy = createProxyMiddleware(context, {
+    proxyTimeout: 3000,
     target: target,
     // Handle errors to prevent the proxy middleware from crashing when
     // the ASP NET Core webserver is unavailable


### PR DESCRIPTION
Add a proxy timeout in the proxy config settings to ensure that the proxy responds timely when the request is cancelled on .NET

[#44638](https://github.com/dotnet/aspnetcore/issues/44638) (section 3)