### PR TITLE
Fix inconsistent casing of template parameters

### DIFF
--- a/src/content/Angular-CSharp/.template.config/dotnetcli.host.json
+++ b/src/content/Angular-CSharp/.template.config/dotnetcli.host.json
@@ -40,6 +40,10 @@
     "UseProgramMain": {
       "longName": "use-program-main",
       "shortName": ""
+    },
+    "ProxyPort": {
+      "longName": "proxy-port",
+      "shortName": "p"
     }
   },
   "usageExamples": [

--- a/src/content/React-CSharp/.template.config/dotnetcli.host.json
+++ b/src/content/React-CSharp/.template.config/dotnetcli.host.json
@@ -40,6 +40,10 @@
     "UseProgramMain": {
       "longName": "use-program-main",
       "shortName": ""
+    },
+    "ProxyPort": {
+      "longName": "proxy-port",
+      "shortName": "p"
     }
   },
   "usageExamples": [


### PR DESCRIPTION
Fixes dotnet/aspnetcore#40970. It changes --ProxyPort to --proxy-port in 2 different templates. The shortname becomes -p since it's available and better than the default -pp. To verify use `dotnet new install <templatefolder>`. 