### PR TITLE
add ".angular" to gitignore of the angular template

### DIFF
--- a/src/content/Angular-CSharp/.gitignore
+++ b/src/content/Angular-CSharp/.gitignore
@@ -229,3 +229,6 @@ _Pvt_Extensions
 
 # FAKE - F# Make
 .fake/
+
+# Angular
+.angular


### PR DESCRIPTION
Angular uses the ".angular/" folder for caching files, as it is not included in the .gitignore one has to add it manually after the first build. This fixes that issue.