### PR TITLE
add ".angular" folder to gitignore of the angular template

### DIFF
--- a/src/content/Angular-CSharp/ClientApp/.gitignore
+++ b/src/content/Angular-CSharp/ClientApp/.gitignore
@@ -38,3 +38,6 @@ testem.log
 # System Files
 .DS_Store
 Thumbs.db
+
+# Angular
+.angular


### PR DESCRIPTION
Angular uses the ".angular/" folder for caching files, as it is not included in the .gitignore one has to add it manually after the first build. This fixes that issue.

Sorry for opening the first PR without reviewing that there where multiple gitignore files.
I thought adding it to the ClientApp file is more fitting. 